### PR TITLE
TurtleApp accepts argc by reference

### DIFF
--- a/turtlesim/src/turtlesim.cpp
+++ b/turtlesim/src/turtlesim.cpp
@@ -38,7 +38,7 @@ class TurtleApp : public QApplication
 public:
   ros::NodeHandlePtr nh_;
 
-  TurtleApp(int argc, char** argv)
+  TurtleApp(int& argc, char** argv)
     : QApplication(argc, argv)
   {
     ros::init(argc, argv, "turtlesim", ros::init_options::NoSigintHandler);


### PR DESCRIPTION
Otherwise running turtlesim_node with a command line argument, such as
`rosrun turtlesim turtlesim_node __name:=sim`
produces a segmentation fault with the following crash report on OSX

<pre>
Thread 0 Crashed:: Dispatch queue: com.apple.main-thread
0   QtCore                          0x000000010a2c1047 QString::fromLocal8Bit(char const*, int) + 25
1   QtCore                          0x000000010a358fc2 QCoreApplication::arguments() + 98
2   QtGui                           0x0000000109793a34 -[QCocoaApplicationDelegate application:openFiles:] + 222
3   com.apple.AppKit                0x00007fff89907f16 -[NSApplication _doOpenFile:ok:tryTemp:] + 274
4   com.apple.AppKit                0x00007fff896501ef -[NSApplication finishLaunching] + 1678
5   com.apple.AppKit                0x00007fff8964f860 -[NSApplication run] + 125
6   QtGui                           0x000000010979ae11 QEventDispatcherMac::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) + 461
7   QtCore                          0x000000010a354d89 QEventLoop::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) + 79
8   QtCore                          0x000000010a354ee7 QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) + 341
9   QtCore                          0x000000010a357a6b QCoreApplication::exec() + 199
10  turtlesim_node                  0x000000010963e238 TurtleApp::exec() + 104
11  turtlesim_node                  0x000000010963de82 main + 66
12  turtlesim_node                  0x000000010963de34 start + 52
</pre>


See discussion at http://qt-project.org/forums/viewthread/18703/
