### PR TITLE
Pylint fixes for talker.py

### DIFF
--- a/rospy_tutorials/001_talker_listener/talker.py
+++ b/rospy_tutorials/001_talker_listener/talker.py
@@ -42,14 +42,15 @@ from std_msgs.msg import String
 def talker():
     pub = rospy.Publisher('chatter', String, queue_size=10)
     rospy.init_node('talker', anonymous=True)
-    r = rospy.Rate(10) # 10hz
+    rate = rospy.Rate(10) # 10hz
     while not rospy.is_shutdown():
-        str = "hello world %s"%rospy.get_time()
-        rospy.loginfo(str)
-        pub.publish(str)
-        r.sleep()
-        
+        hello_str = "hello world %s" % rospy.get_time()
+        rospy.loginfo(hello_str)
+        pub.publish(hello_str)
+        rate.sleep()
+
 if __name__ == '__main__':
     try:
         talker()
-    except rospy.ROSInterruptException: pass
+    except rospy.ROSInterruptException:
+        pass


### PR DESCRIPTION
- don't override built-in 'str'
- spaces around operators
- one statement per line
- whitespace cleanup
- single letter variable names are invalid, rename
