### PR TITLE
Pylint and grammar fixes for listener.py

### DIFF
--- a/rospy_tutorials/001_talker_listener/listener.py
+++ b/rospy_tutorials/001_talker_listener/listener.py
@@ -40,12 +40,12 @@ import rospy
 from std_msgs.msg import String
 
 def callback(data):
-    rospy.loginfo(rospy.get_caller_id()+"I heard %s",data.data)
-    
+    rospy.loginfo(rospy.get_caller_id() + "I heard %s", data.data)
+
 def listener():
 
-    # in ROS, nodes are unique named. If two nodes with the same
-    # node are launched, the previous one is kicked off. The 
+    # In ROS, nodes are uniquely named. If two nodes with the same
+    # node are launched, the previous one is kicked off. The
     # anonymous=True flag means that rospy will choose a unique
     # name for our 'talker' node so that multiple talkers can
     # run simultaenously.
@@ -55,6 +55,6 @@ def listener():
 
     # spin() simply keeps python from exiting until this node is stopped
     rospy.spin()
-        
+
 if __name__ == '__main__':
     listener()


### PR DESCRIPTION
- whitespace cleanup
- spaces around operators and following commas
- Punctuation / grammar in comments.
