### PR TITLE
Shorten comment line length to avoid overflow on wiki.ros.org.

### DIFF
--- a/roscpp_tutorials/listener/listener.cpp
+++ b/roscpp_tutorials/listener/listener.cpp
@@ -43,10 +43,10 @@ int main(int argc, char **argv)
 {
   /**
    * The ros::init() function needs to see argc and argv so that it can perform
-   * any ROS arguments and name remapping that were provided at the command line. For programmatic
-   * remappings you can use a different version of init() which takes remappings
-   * directly, but for most command-line programs, passing argc and argv is the easiest
-   * way to do it.  The third argument to init() is the name of the node.
+   * any ROS arguments and name remapping that were provided at the command line.
+   * For programmatic remappings you can use a different version of init() which takes
+   * remappings directly, but for most command-line programs, passing argc and argv is
+   * the easiest way to do it.  The third argument to init() is the name of the node.
    *
    * You must call one of the versions of ros::init() before using any other
    * part of the ROS system.

--- a/roscpp_tutorials/talker/talker.cpp
+++ b/roscpp_tutorials/talker/talker.cpp
@@ -41,10 +41,10 @@ int main(int argc, char **argv)
 {
   /**
    * The ros::init() function needs to see argc and argv so that it can perform
-   * any ROS arguments and name remapping that were provided at the command line. For programmatic
-   * remappings you can use a different version of init() which takes remappings
-   * directly, but for most command-line programs, passing argc and argv is the easiest
-   * way to do it.  The third argument to init() is the name of the node.
+   * any ROS arguments and name remapping that were provided at the command line.
+   * For programmatic remappings you can use a different version of init() which takes
+   * remappings directly, but for most command-line programs, passing argc and argv is
+   * the easiest way to do it.  The third argument to init() is the name of the node.
    *
    * You must call one of the versions of ros::init() before using any other
    * part of the ROS system.


### PR DESCRIPTION
I'm not sure what your policy is on PRs, but I figured I give it a shot regardless.

The commented line ending with "For programmatic" was overflowing and wrapping around on wiki.ros.org (specifically http://wiki.ros.org/ROS/Tutorials/WritingPublisherSubscriber%28c%2B%2B%29). I've shortened the line in question to fix the issue in the two examples on that page.
