### PR TITLE
Theta range from -p to +pi instead of -2pi to +2pi.

### DIFF
--- a/turtlesim/src/turtle.cpp
+++ b/turtlesim/src/turtle.cpp
@@ -148,7 +148,9 @@ bool Turtle::update(double dt, QPainter& path_painter, const QImage& path_image,
 
   QPointF old_pos = pos_;
 
-  orient_ = std::fmod(orient_ + ang_vel_ * dt, 2*PI);
+  orient_ = orient_ + ang_vel_ * dt;
+  // Keep orient_ between -pi and +pi
+  orient_ -= 2*PI * std::floor((orient_ + PI)/(2*PI));
   pos_.rx() += std::sin(orient_ + PI/2.0) * lin_vel_ * dt;
   pos_.ry() += std::cos(orient_ + PI/2.0) * lin_vel_ * dt;
 


### PR DESCRIPTION
Range of `theta` now from 0 to 2PI not from -2PI to 2PI.
No negative values when rotating clockwise now.

Thanks for the help @v4hn!
