### PR TITLE
Check pen_on_ when processing teleport requests

### DIFF
--- a/turtlesim/src/turtle.cpp
+++ b/turtlesim/src/turtle.cpp
@@ -133,8 +133,11 @@ bool Turtle::update(double dt, QPainter& path_painter, const QImage& path_image,
       orient_ = req.theta;
     }
 
-    path_painter.setPen(pen_);
-    path_painter.drawLine(pos_ * meter_, old_pos * meter_);
+    if (pen_on_)
+    {
+      path_painter.setPen(pen_);
+      path_painter.drawLine(pos_ * meter_, old_pos * meter_);
+    }
     modified = true;
   }
 


### PR DESCRIPTION
Fixes a bug where the turtle would paint its path during teleportation despite the pen being turned off.
