### PR TITLE
Fixing issue #43, with [-pi, pi) scope for theta

### DIFF
--- a/turtlesim/src/turtle.cpp
+++ b/turtlesim/src/turtle.cpp
@@ -152,10 +152,8 @@ bool Turtle::update(double dt, QPainter& path_painter, const QImage& path_image,
   QPointF old_pos = pos_;
 
   orient_ = orient_ + ang_vel_ * dt;
-  // Keep orient_ between 0 and +pi*2
-  orient_ -= 2*PI * std::floor(orient_/(2*PI));
-  
-  
+  // Keep orient_ between -pi and +pi
+  orient_ -= 2*PI * std::floor((orient_ + PI)/(2*PI));
   pos_.rx() += std::sin(orient_ + PI/2.0) * lin_vel_ * dt;
   pos_.ry() += std::cos(orient_ + PI/2.0) * lin_vel_ * dt;
 

--- a/turtlesim/src/turtle.cpp
+++ b/turtlesim/src/turtle.cpp
@@ -152,8 +152,10 @@ bool Turtle::update(double dt, QPainter& path_painter, const QImage& path_image,
   QPointF old_pos = pos_;
 
   orient_ = orient_ + ang_vel_ * dt;
-  // Keep orient_ between -pi and +pi
-  orient_ -= 2*PI * std::floor((orient_ + PI)/(2*PI));
+  // Keep orient_ between 0 and +pi*2
+  orient_ -= 2*PI * std::floor(orient_/(2*PI));
+  
+  
   pos_.rx() += std::sin(orient_ + PI/2.0) * lin_vel_ * dt;
   pos_.ry() += std::cos(orient_ + PI/2.0) * lin_vel_ * dt;
 

--- a/turtlesim/tutorials/draw_square.cpp
+++ b/turtlesim/tutorials/draw_square.cpp
@@ -58,8 +58,8 @@ void stopForward(ros::Publisher twist_pub)
     g_goal.x = g_pose->x;
     g_goal.y = g_pose->y;
     g_goal.theta = fmod(g_pose->theta + PI/2.0, 2*PI);
-    //wrap g_goal.theta to [-pi, pi)
-    if (g_goal.theta>=PI) g_goal.theta -= 2*PI;
+    // wrap g_goal.theta to [-pi, pi)
+    if (g_goal.theta >= PI) g_goal.theta -= 2 * PI;
     printGoal();
   }
   else

--- a/turtlesim/tutorials/draw_square.cpp
+++ b/turtlesim/tutorials/draw_square.cpp
@@ -58,6 +58,8 @@ void stopForward(ros::Publisher twist_pub)
     g_goal.x = g_pose->x;
     g_goal.y = g_pose->y;
     g_goal.theta = fmod(g_pose->theta + PI/2.0, 2*PI);
+    //wrap g_goal.theta to [-pi, pi)
+    if (g_goal.theta>=PI) g_goal.theta -= 2*PI;
     printGoal();
   }
   else


### PR DESCRIPTION
The fix proposed by  jarvisschultz (#45) is nice but it introduces two new functions in `draw_square.cpp`, which, IMHO, makes the tutorial code unnecessarily more complicated. Besides, its newly introduced functions use the built-in constant M_PI (3.14159265358979323846264338327950288),  rather than PI defined in `draw_square.cpp` (3.141592) -- the inconsistency would make the tutorial harder to understand, which  could potentially trigger hard-to-detect, floating-point-related bugs later on (e.g. when the turtle moves for longer time).

Therefore, I have proposed a simpler, one-line solution that avoids the aforementioned issues. Given that the convention is to have the angle of a turtlesim/Pose to be within [-pi,pi), the fix just added one line in draw_square.cpp that follows this convention. 