### PR TITLE
add missing dependency for tests

### DIFF
--- a/rospy_tutorials/package.xml
+++ b/rospy_tutorials/package.xml
@@ -23,4 +23,6 @@
   <run_depend>message_runtime</run_depend>
   <run_depend>rospy</run_depend>
   <run_depend>std_msgs</run_depend>
+
+  <test_depend>roscpp_tutorials</test_depend>
 </package>


### PR DESCRIPTION
E.g. for https://github.com/ros/ros_tutorials/blob/2b1de43ba413bf59bbb7eb0578bf79e1721049de/rospy_tutorials/test/test-talker-listener-with-roscpp.launch#L2