### PR TITLE
Update turtlesim mimic tutorial node.

### DIFF
--- a/turtlesim/tutorials/mimic.cpp
+++ b/turtlesim/tutorials/mimic.cpp
@@ -2,40 +2,32 @@
 #include <turtlesim/msg/pose.hpp>
 #include <geometry_msgs/msg/twist.hpp>
 
-class Mimic
+class MimicNode : public rclcpp::Node
 {
 public:
-  Mimic();
+  MimicNode() : rclcpp::Node("turtle_mimic")
+  {
+    twist_pub_ = this->create_publisher<geometry_msgs::msg::Twist>("output/cmd_vel", 1);
+    pose_sub_ = this->create_subscription<turtlesim::msg::Pose>(
+      "input/pose", 1, std::bind(&MimicNode::poseCallback, this, std::placeholders::_1));
+  }
 
 private:
-  void poseCallback(const turtlesim::msg::Pose::SharedPtr pose);
+  void poseCallback(const turtlesim::msg::Pose::SharedPtr pose)
+  {
+    geometry_msgs::msg::Twist twist;
+    twist.angular.z = pose->angular_velocity;
+    twist.linear.x = pose->linear_velocity;
+    twist_pub_->publish(twist);
+  }
 
   rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr twist_pub_;
   rclcpp::Subscription<turtlesim::msg::Pose>::SharedPtr pose_sub_;
 };
 
-Mimic::Mimic()
-{
-  auto input_nh = rclcpp::Node::make_shared("input");
-  auto output_nh = rclcpp::Node::make_shared("output");
-  twist_pub_ = output_nh->create_publisher<geometry_msgs::msg::Twist>("cmd_vel", 1);
-  pose_sub_ = input_nh->create_subscription<turtlesim::msg::Pose>("pose", 1, std::bind(&Mimic::poseCallback, this, std::placeholders::_1));
-}
-
-void Mimic::poseCallback(const turtlesim::msg::Pose::SharedPtr pose)
-{
-  geometry_msgs::msg::Twist twist;
-  twist.angular.z = pose->angular_velocity;
-  twist.linear.x = pose->linear_velocity;
-  twist_pub_->publish(twist);
-}
-
 int main(int argc, char** argv)
 {
   rclcpp::init(argc, argv);
-  auto nh = rclcpp::Node::make_shared("turtle_mimic");
-  Mimic mimic;
-
-  rclcpp::spin(nh);
+  rclcpp::spin(std::make_shared<MimicNode>());
 }
 


### PR DESCRIPTION
This pull request refactors the `mimic` node,  a `turtlesim` tutorial, as it does not currently behave as it ought to. Mainly, `rclcpp::Node` was used as if it were a ROS1 `NodeHandle` equivalent -- variable naming suggests so. 

I also took the liberty to push it closer to the `rclcpp::Node` subclassing idiom.