### PR TITLE
Fix Typo in teleop_turtle_key.cpp

### DIFF
--- a/turtlesim/tutorials/teleop_turtle_key.cpp
+++ b/turtlesim/tutorials/teleop_turtle_key.cpp
@@ -82,7 +82,7 @@ public:
         }
         else if (buffer.Event.KeyEvent.wVirtualKeyCode == VK_DOWN)
         {
-          *c = KEYCODE_DDOWN;
+          *c = KEYCODE_DOWN;
           return;
         }
         else if (buffer.Event.KeyEvent.wVirtualKeyCode == 0x42)


### PR DESCRIPTION
This is causing failures on the Windows 10 Packaging job.

Snippet from [here](https://ci.ros2.org/view/packaging/job/packaging_windows/lastBuild/console#console-section-11)

```
05:11:35 C:\J\workspace\packaging_windows\ws\src\ros\ros_tutorials\turtlesim\tutorials\teleop_turtle_key.cpp(85): error C2065: 'KEYCODE_DDOWN': undeclared identifier [C:\J\workspace\packaging_windows\ws\build\turtlesim\turtle_teleop_key.vcxproj]
05:11:35 C:\J\workspace\packaging_windows\ws\src\ros\ros_tutorials\turtlesim\tutorials\teleop_turtle_key.cpp(193): warning C4244: '=': conversion from 'double' to 'turtlesim::action::RotateAbsolute_Goal_<std::allocator<void>>::_theta_type', possible loss of data [C:\J\workspace\packaging_windows\ws\build\turtlesim\turtle_teleop_key.vcxproj]
```
