### PR TITLE
Replace deprecated launch_ros usage

### DIFF
--- a/turtlesim/launch/multisim.launch.py
+++ b/turtlesim/launch/multisim.launch.py
@@ -4,7 +4,7 @@ import launch_ros.actions
 def generate_launch_description():
     return LaunchDescription([
         launch_ros.actions.Node(
-            node_namespace= "turtlesim1", package='turtlesim', node_executable='turtlesim_node', output='screen'),
+            namespace= "turtlesim1", package='turtlesim', executable='turtlesim_node', output='screen'),
         launch_ros.actions.Node(
-            node_namespace= "turtlesim2", package='turtlesim', node_executable='turtlesim_node', output='screen'),
+            namespace= "turtlesim2", package='turtlesim', executable='turtlesim_node', output='screen'),
     ])


### PR DESCRIPTION
Several Node parameters have been deprecated and replaced with new
parameters with different names.

Depends on https://github.com/ros2/launch_ros/pull/140

Maybe it makes sense to target a new `foxy-devel` branch instead, since this change only applies to Foxy.