### PR TITLE
Default construct Qt::WindowFlags

### DIFF
--- a/turtlesim/include/turtlesim/turtle_frame.h
+++ b/turtlesim/include/turtlesim/turtle_frame.h
@@ -55,7 +55,7 @@ class TurtleFrame : public QFrame
 {
   Q_OBJECT
 public:
-  TurtleFrame(rclcpp::Node::SharedPtr& node_handle, QWidget* parent = 0, Qt::WindowFlags f = 0);
+  TurtleFrame(rclcpp::Node::SharedPtr& node_handle, QWidget* parent = 0, Qt::WindowFlags f = Qt::WindowFlags());
   ~TurtleFrame();
 
   std::string spawnTurtle(const std::string& name, float x, float y, float angle);


### PR DESCRIPTION
This fixes a compiler warning "'QFlags::QFlags': Use default constructor instead"

The warning shows up in our Windows CI, [for example](https://ci.ros2.org/view/packaging/job/packaging_windows/1758/msbuild/folder.1819479119/).

Windows: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=10859)](https://ci.ros2.org/job/ci_windows/10859/)