### PR TITLE
Add step value to turtlesim color parameters

### DIFF
--- a/turtlesim/src/turtle_frame.cpp
+++ b/turtlesim/src/turtle_frame.cpp
@@ -62,6 +62,7 @@ TurtleFrame::TurtleFrame(rclcpp::Node::SharedPtr& node_handle, QWidget* parent, 
   nh_ = node_handle;
   rcl_interfaces::msg::IntegerRange range;
   range.from_value = 0;
+  range.step = 1;
   range.to_value = 255;
   rcl_interfaces::msg::ParameterDescriptor background_r_descriptor;
   background_r_descriptor.description = "Red channel of the background color";


### PR DESCRIPTION
The step value defaults to 0, which renders stepwise changes to the parameters in `rqt_reconfigure`, such as keyboard or mouse scroll controls, impossible.