### PR TITLE
Add holonomic motion for turtlesim (eloquent)

### DIFF
--- a/turtlesim/include/turtlesim/turtle.h
+++ b/turtlesim/include/turtlesim/turtle.h
@@ -81,7 +81,8 @@ private:
   QPointF pos_;
   qreal orient_;
 
-  qreal lin_vel_;
+  qreal lin_vel_x_;
+  qreal lin_vel_y_;
   qreal ang_vel_;
   bool pen_on_;
   QPen pen_;

--- a/turtlesim/src/turtle.cpp
+++ b/turtlesim/src/turtle.cpp
@@ -51,7 +51,8 @@ Turtle::Turtle(rclcpp::Node::SharedPtr& nh, const std::string& real_name, const 
 , turtle_image_(turtle_image)
 , pos_(pos)
 , orient_(orient)
-, lin_vel_(0.0)
+, lin_vel_x_(0.0)
+, lin_vel_y_(0.0)
 , ang_vel_(0.0)
 , pen_on_(true)
 , pen_(QColor(DEFAULT_PEN_R, DEFAULT_PEN_G, DEFAULT_PEN_B))
@@ -90,7 +91,8 @@ Turtle::Turtle(rclcpp::Node::SharedPtr& nh, const std::string& real_name, const 
 void Turtle::velocityCallback(const geometry_msgs::msg::Twist::SharedPtr vel)
 {
   last_command_time_ = nh_->now();
-  lin_vel_ = vel->linear.x;
+  lin_vel_x_ = vel->linear.x;
+  lin_vel_y_ = vel->linear.y;
   ang_vel_ = vel->angular.z;
 
   // Abort any active action
@@ -233,7 +235,8 @@ bool Turtle::update(double dt, QPainter& path_painter, const QImage& path_image,
 
   if (nh_->now() - last_command_time_ > rclcpp::Duration(1.0, 0))
   {
-    lin_vel_ = 0.0;
+    lin_vel_x_ = 0.0;
+    lin_vel_y_ = 0.0;
     ang_vel_ = 0.0;
   }
 
@@ -242,8 +245,10 @@ bool Turtle::update(double dt, QPainter& path_painter, const QImage& path_image,
   orient_ = orient_ + ang_vel_ * dt;
   // Keep orient_ between -pi and +pi
   orient_ = normalizeAngle(orient_);
-  pos_.rx() += std::cos(orient_) * lin_vel_ * dt;
-  pos_.ry() += - std::sin(orient_) * lin_vel_ * dt;
+  pos_.rx() += std::cos(orient_) * lin_vel_x_ * dt
+             - std::sin(orient_) * lin_vel_y_ * dt;
+  pos_.ry() -= std::cos(orient_) * lin_vel_y_ * dt
+             + std::sin(orient_) * lin_vel_x_ * dt;
 
   // Clamp to screen size
   if (pos_.x() < 0 || pos_.x() > canvas_width ||
@@ -260,7 +265,7 @@ bool Turtle::update(double dt, QPainter& path_painter, const QImage& path_image,
   p->x = pos_.x();
   p->y = canvas_height - pos_.y();
   p->theta = orient_;
-  p->linear_velocity = lin_vel_;
+  p->linear_velocity = std::sqrt(lin_vel_x_ * lin_vel_x_ + lin_vel_y_ * lin_vel_y_);
   p->angular_velocity = ang_vel_;
   pose_pub_->publish(std::move(p));
 


### PR DESCRIPTION
This PR adds the feature to move the turtle forward by [geometry_msgs/Twist](http://docs.ros.org/melodic/api/geometry_msgs/html/msg/Twist.html) message `linear.x` and `linear.y`.
Related to #93.