### PR TITLE
Update goal response callback signature

### DIFF
--- a/turtlesim/tutorials/teleop_turtle_key.cpp
+++ b/turtlesim/tutorials/teleop_turtle_key.cpp
@@ -161,7 +161,6 @@ public:
 private:
   void spin();
   void sendGoal(float theta);
-  void goalResponseCallback(std::shared_future<rclcpp_action::ClientGoalHandle<turtlesim::action::RotateAbsolute>::SharedPtr> future);
   void cancelGoal();
   
   rclcpp::Node::SharedPtr nh_;
@@ -193,18 +192,12 @@ void TeleopTurtle::sendGoal(float theta)
   goal.theta = theta;
   auto send_goal_options = rclcpp_action::Client<turtlesim::action::RotateAbsolute>::SendGoalOptions();
   send_goal_options.goal_response_callback =
-    [this](std::shared_future<rclcpp_action::ClientGoalHandle<turtlesim::action::RotateAbsolute>::SharedPtr> future)
+    [this](rclcpp_action::ClientGoalHandle<turtlesim::action::RotateAbsolute>::SharedPtr goal_handle)
     {
       RCLCPP_DEBUG(nh_->get_logger(), "Goal response received");
-      this->goal_handle_ = future.get();
+      this->goal_handle_ = goal_handle;
     };
   rotate_absolute_client_->async_send_goal(goal, send_goal_options);
-}
-
-void TeleopTurtle::goalResponseCallback(std::shared_future<rclcpp_action::ClientGoalHandle<turtlesim::action::RotateAbsolute>::SharedPtr> future)
-{
-  RCLCPP_DEBUG(nh_->get_logger(), "Goal response received");
-  this->goal_handle_ = future.get();
 }
 
 void TeleopTurtle::cancelGoal()


### PR DESCRIPTION
The signature changed in https://github.com/ros2/rclcpp/pull/1311

Also remove related dead code.

Since this is not compatible with Foxy, I've created and targeted a new `galactic-devel` branch.

TODO:

- [x] Update ros2 repos file (https://github.com/ros2/ros2/pull/1034)
- [x] Update rosdistro for Rolling (https://github.com/ros/rosdistro/pull/26613)
- [x] Update release track for Rolling (https://github.com/ros2-gbp/ros_tutorials-release/pull/1)