### PR TITLE
Ignore key up events in teleop_turtle_key on Windows

### DIFF
--- a/turtlesim/tutorials/teleop_turtle_key.cpp
+++ b/turtlesim/tutorials/teleop_turtle_key.cpp
@@ -65,6 +65,10 @@ public:
       if(events > 0)
       {
         ReadConsoleInput(handle, &buffer, 1, &events);
+        if (!buffer.Event.KeyEvent.bKeyDown)
+        {
+          continue;
+        }
         if (buffer.Event.KeyEvent.wVirtualKeyCode == VK_LEFT)
         {
           *c = KEYCODE_LEFT;


### PR DESCRIPTION
Precisely what the title says. Without this, goals were sent twice, resulting in:

```sh
C:\opt\ros>ros2 run turtlesim turtlesim_node
[INFO] [1618522185.883591800] [turtlesim]: Starting turtlesim with node name /turtlesim
[INFO] [1618522185.899227100] [turtlesim]: Spawning turtle [turtle1] at x=[5.544445], y=[5.544445], theta=[0.000000]
[INFO] [1618522191.815428400] [turtlesim]: Rotation goal completed successfully
[INFO] [1618522191.878537900] [turtlesim]: Rotation goal completed successfully
[WARN] [1618522207.286362400] [turtlesim]: Rotation goal received before a previous goal finished. Aborting previous goal
[INFO] [1618522209.606408200] [turtlesim]: Rotation goal completed successfully
```