### PR TITLE
Print out the correct node name on startup.

### DIFF
--- a/turtlesim/src/turtle_frame.cpp
+++ b/turtlesim/src/turtle_frame.cpp
@@ -106,7 +106,7 @@ TurtleFrame::TurtleFrame(rclcpp::Node::SharedPtr& node_handle, QWidget* parent, 
   parameter_event_sub_ = nh_->create_subscription<rcl_interfaces::msg::ParameterEvent>(
     "/parameter_events", qos, std::bind(&TurtleFrame::parameterEventCallback, this, std::placeholders::_1));
 
-  RCLCPP_INFO(nh_->get_logger(), "Starting turtlesim with node name %s", nh_->get_node_names()[0].c_str());
+  RCLCPP_INFO(nh_->get_logger(), "Starting turtlesim with node name %s", nh_->get_fully_qualified_name());
 
   width_in_meters_ = (width() - 1) / meter_;
   height_in_meters_ = (height() - 1) / meter_;


### PR DESCRIPTION
Previously, this code was calling 'get_node_names()' and just
choosing the first out of the list.  But that could be literally
anything if there are other nodes running in the network.
Instead, call 'get_fully_qualified_name()' instead to get the
name of this node.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>