### PR TITLE
Add holonomic motion disable option (ROS 1 turtlesim)

### DIFF
--- a/turtlesim/include/turtlesim/turtle.h
+++ b/turtlesim/include/turtlesim/turtle.h
@@ -56,7 +56,7 @@ namespace turtlesim
 class Turtle
 {
 public:
-  Turtle(const ros::NodeHandle& nh, const QImage& turtle_image, const QPointF& pos, float orient);
+  Turtle(const ros::NodeHandle& nh, const QImage& turtle_image, const QPointF& pos, float orient, bool holonomic);
 
   bool update(double dt, QPainter& path_painter, const QImage& path_image, qreal canvas_width, qreal canvas_height);
   void paint(QPainter &painter);
@@ -75,6 +75,7 @@ private:
 
   QPointF pos_;
   qreal orient_;
+  bool holonomic_;
 
   qreal lin_vel_x_;
   qreal lin_vel_y_;

--- a/turtlesim/include/turtlesim/turtle_frame.h
+++ b/turtlesim/include/turtlesim/turtle_frame.h
@@ -56,8 +56,8 @@ public:
   TurtleFrame(QWidget* parent = 0, Qt::WindowFlags f = 0);
   ~TurtleFrame();
 
-  std::string spawnTurtle(const std::string& name, float x, float y, float angle);
-  std::string spawnTurtle(const std::string& name, float x, float y, float angle, size_t index);
+  std::string spawnTurtle(const std::string& name, float x, float y, float angle, bool holonomic);
+  std::string spawnTurtle(const std::string& name, float x, float y, float angle, size_t index, bool holonomic);
 
 protected:
   void paintEvent(QPaintEvent* event);
@@ -99,6 +99,7 @@ private:
   float meter_;
   float width_in_meters_;
   float height_in_meters_;
+  bool holonomic_;
 };
 
 }

--- a/turtlesim/src/turtle.cpp
+++ b/turtlesim/src/turtle.cpp
@@ -39,11 +39,12 @@
 namespace turtlesim
 {
 
-Turtle::Turtle(const ros::NodeHandle& nh, const QImage& turtle_image, const QPointF& pos, float orient)
+Turtle::Turtle(const ros::NodeHandle& nh, const QImage& turtle_image, const QPointF& pos, float orient, bool holonomic)
 : nh_(nh)
 , turtle_image_(turtle_image)
 , pos_(pos)
 , orient_(orient)
+, holonomic_(holonomic)
 , lin_vel_x_(0.0)
 , lin_vel_y_(0.0)
 , ang_vel_(0.0)
@@ -63,12 +64,14 @@ Turtle::Turtle(const ros::NodeHandle& nh, const QImage& turtle_image, const QPoi
   rotateImage();
 }
 
-
 void Turtle::velocityCallback(const geometry_msgs::Twist::ConstPtr& vel)
 {
   last_command_time_ = ros::WallTime::now();
   lin_vel_x_ = vel->linear.x;
-  lin_vel_y_ = vel->linear.y;
+  if (holonomic_) 
+  {
+    lin_vel_y_ = vel->linear.y;
+  }
   ang_vel_ = vel->angular.z;
 }
 


### PR DESCRIPTION
This PR adds an option to turtlesim to disable holonomic motion.

Related issue: https://github.com/ros/ros_tutorials/issues/127

Usage 

```sh
rosrun turtlesim turtlesim_node _holonomic:=false
```

```xml
<arg name="holonomic" default="false" />
<node pkg="turtlesim" name="sim" type="turtlesim_node">
  <param name="holonomic" value="$(arg false)" />
</node>
```
![Screenshot from 2021-07-11 03-04-42](https://user-images.githubusercontent.com/3256629/125172443-c21ecb80-e1f4-11eb-9a86-00f8909b1bec.png)

Note that the most right terminal shows the `teleop_twist_keyboard.py`, which is not contained in this PR.