### PR TITLE
Use rosidl_get_typesupport_target()

### DIFF
--- a/turtlesim/CMakeLists.txt
+++ b/turtlesim/CMakeLists.txt
@@ -44,21 +44,22 @@ set(turtlesim_node_HDRS
 
 qt5_wrap_cpp(turtlesim_node_MOCS ${turtlesim_node_HDRS})
 
+rosidl_get_typesupport_target(cpp_typesupport_target "${PROJECT_NAME}" "rosidl_typesupport_cpp")
 
 add_executable(turtlesim_node ${turtlesim_node_SRCS} ${turtlesim_node_MOCS})
 target_link_libraries(turtlesim_node Qt5::Widgets)
 ament_target_dependencies(turtlesim_node ${dependencies})
-rosidl_target_interfaces(turtlesim_node ${PROJECT_NAME} "rosidl_typesupport_cpp")
+target_link_libraries(turtlesim_node "${cpp_typesupport_target}")
 
 add_executable(turtle_teleop_key tutorials/teleop_turtle_key.cpp)
 ament_target_dependencies(turtle_teleop_key ${dependencies})
-rosidl_target_interfaces(turtle_teleop_key ${PROJECT_NAME} "rosidl_typesupport_cpp")
+target_link_libraries(turtle_teleop_key "${cpp_typesupport_target}")
 add_executable(draw_square tutorials/draw_square.cpp)
 ament_target_dependencies(draw_square ${dependencies})
-rosidl_target_interfaces(draw_square ${PROJECT_NAME} "rosidl_typesupport_cpp")
+target_link_libraries(draw_square "${cpp_typesupport_target}")
 add_executable(mimic tutorials/mimic.cpp)
 ament_target_dependencies(mimic ${dependencies})
-rosidl_target_interfaces(mimic ${PROJECT_NAME} "rosidl_typesupport_cpp")
+target_link_libraries(mimic "${cpp_typesupport_target}")
 
 install(TARGETS turtlesim_node turtle_teleop_key draw_square mimic
   DESTINATION lib/${PROJECT_NAME})


### PR DESCRIPTION
Part of ros2/rosidl#606 which deprecates `rosidl_target_interfaces()` in favor of `rosidl_get_typesupport_target()`