### PR TITLE
Fix deprecated subscriber callback warnings

### DIFF
--- a/turtlesim/include/turtlesim/turtle.h
+++ b/turtlesim/include/turtlesim/turtle.h
@@ -65,7 +65,7 @@ public:
   bool update(double dt, QPainter& path_painter, const QImage& path_image, qreal canvas_width, qreal canvas_height);
   void paint(QPainter &painter);
 private:
-  void velocityCallback(const geometry_msgs::msg::Twist::SharedPtr vel);
+  void velocityCallback(const geometry_msgs::msg::Twist::ConstSharedPtr vel);
   bool setPenCallback(const turtlesim::srv::SetPen::Request::SharedPtr, turtlesim::srv::SetPen::Response::SharedPtr);
   bool teleportRelativeCallback(const turtlesim::srv::TeleportRelative::Request::SharedPtr, turtlesim::srv::TeleportRelative::Response::SharedPtr);
   bool teleportAbsoluteCallback(const turtlesim::srv::TeleportAbsolute::Request::SharedPtr, turtlesim::srv::TeleportAbsolute::Response::SharedPtr);

--- a/turtlesim/include/turtlesim/turtle_frame.h
+++ b/turtlesim/include/turtlesim/turtle_frame.h
@@ -77,7 +77,7 @@ private:
   bool spawnCallback(const turtlesim::srv::Spawn::Request::SharedPtr, turtlesim::srv::Spawn::Response::SharedPtr);
   bool killCallback(const turtlesim::srv::Kill::Request::SharedPtr, turtlesim::srv::Kill::Response::SharedPtr);
 
-  void parameterEventCallback(const rcl_interfaces::msg::ParameterEvent::SharedPtr);
+  void parameterEventCallback(const rcl_interfaces::msg::ParameterEvent::ConstSharedPtr);
 
   rclcpp::Node::SharedPtr nh_;
 

--- a/turtlesim/src/turtle.cpp
+++ b/turtlesim/src/turtle.cpp
@@ -88,7 +88,7 @@ Turtle::Turtle(rclcpp::Node::SharedPtr& nh, const std::string& real_name, const 
 }
 
 
-void Turtle::velocityCallback(const geometry_msgs::msg::Twist::SharedPtr vel)
+void Turtle::velocityCallback(const geometry_msgs::msg::Twist::ConstSharedPtr vel)
 {
   last_command_time_ = nh_->now();
   lin_vel_x_ = vel->linear.x;

--- a/turtlesim/src/turtle_frame.cpp
+++ b/turtlesim/src/turtle_frame.cpp
@@ -160,12 +160,12 @@ bool TurtleFrame::killCallback(const turtlesim::srv::Kill::Request::SharedPtr re
   return true;
 }
 
-void TurtleFrame::parameterEventCallback(const rcl_interfaces::msg::ParameterEvent::SharedPtr event)
+void TurtleFrame::parameterEventCallback(const rcl_interfaces::msg::ParameterEvent::ConstSharedPtr event)
 {
   // only consider events from this node
   if (event->node == nh_->get_fully_qualified_name())
   {
-    // since parameter events for this even aren't expected frequently just always call update()
+    // since parameter events for this event aren't expected frequently just always call update()
     update();
   }
 }

--- a/turtlesim/tutorials/draw_square.cpp
+++ b/turtlesim/tutorials/draw_square.cpp
@@ -4,7 +4,7 @@
 #include <std_srvs/srv/empty.hpp>
 #include <math.h>
 
-turtlesim::msg::Pose::SharedPtr g_pose;
+turtlesim::msg::Pose g_pose;
 turtlesim::msg::Pose g_goal;
 
 enum State
@@ -18,22 +18,27 @@ enum State
 State g_state = FORWARD;
 State g_last_state = FORWARD;
 bool g_first_goal_set = false;
+bool g_first_pose_set = false;
 
 #define PI 3.141592
 
-void poseCallback(const turtlesim::msg::Pose::SharedPtr pose)
+void poseCallback(const turtlesim::msg::Pose & pose)
 {
   g_pose = pose;
+  if (!g_first_pose_set)
+  {
+    g_first_pose_set = true;
+  }
 }
 
 bool hasReachedGoal()
 {
-  return fabsf(g_pose->x - g_goal.x) < 0.1 && fabsf(g_pose->y - g_goal.y) < 0.1 && fabsf(g_pose->theta - g_goal.theta) < 0.01;
+  return fabsf(g_pose.x - g_goal.x) < 0.1 && fabsf(g_pose.y - g_goal.y) < 0.1 && fabsf(g_pose.theta - g_goal.theta) < 0.01;
 }
 
 bool hasStopped()
 {
-  return g_pose->angular_velocity < 0.0001 && g_pose->linear_velocity < 0.0001;
+  return g_pose.angular_velocity < 0.0001 && g_pose.linear_velocity < 0.0001;
 }
 
 void printGoal()
@@ -55,9 +60,9 @@ void stopForward(rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr twist_p
   {
     RCLCPP_INFO(rclcpp::get_logger("draw_square"), "Reached goal");
     g_state = TURN;
-    g_goal.x = g_pose->x;
-    g_goal.y = g_pose->y;
-    g_goal.theta = fmod(g_pose->theta + static_cast<float>(PI) / 2.0f, 2.0f * static_cast<float>(PI));
+    g_goal.x = g_pose.x;
+    g_goal.y = g_pose.y;
+    g_goal.theta = fmod(g_pose.theta + static_cast<float>(PI) / 2.0f, 2.0f * static_cast<float>(PI));
     // wrap g_goal.theta to [-pi, pi)
     if (g_goal.theta >= static_cast<float>(PI)) g_goal.theta -= 2.0f * static_cast<float>(PI);
     printGoal();
@@ -74,9 +79,9 @@ void stopTurn(rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr twist_pub)
   {
     RCLCPP_INFO(rclcpp::get_logger("draw_square"), "Reached goal");
     g_state = FORWARD;
-    g_goal.x = cos(g_pose->theta) * 2 + g_pose->x;
-    g_goal.y = sin(g_pose->theta) * 2 + g_pose->y;
-    g_goal.theta = g_pose->theta;
+    g_goal.x = cos(g_pose.theta) * 2 + g_pose.x;
+    g_goal.y = sin(g_pose.theta) * 2 + g_pose.y;
+    g_goal.theta = g_pose.theta;
     printGoal();
   }
   else
@@ -114,7 +119,7 @@ void turn(rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr twist_pub)
 
 void timerCallback(rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr twist_pub)
 {
-  if (!g_pose)
+  if (g_first_pose_set)
   {
     return;
   }
@@ -123,9 +128,9 @@ void timerCallback(rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr twist
   {
     g_first_goal_set = true;
     g_state = FORWARD;
-    g_goal.x = cos(g_pose->theta) * 2 + g_pose->x;
-    g_goal.y = sin(g_pose->theta) * 2 + g_pose->y;
-    g_goal.theta = g_pose->theta;
+    g_goal.x = cos(g_pose.theta) * 2 + g_pose.x;
+    g_goal.y = sin(g_pose.theta) * 2 + g_pose.y;
+    g_goal.theta = g_pose.theta;
     printGoal();
   }
 

--- a/turtlesim/tutorials/mimic.cpp
+++ b/turtlesim/tutorials/mimic.cpp
@@ -13,7 +13,7 @@ public:
   }
 
 private:
-  void poseCallback(const turtlesim::msg::Pose::SharedPtr pose)
+  void poseCallback(const turtlesim::msg::Pose::ConstSharedPtr pose)
   {
     geometry_msgs::msg::Twist twist;
     twist.angular.z = pose->angular_velocity;


### PR DESCRIPTION
ros2/rclcpp#1713 deprecates the `void shared_ptr<T>` subscription callback signatures, so this PR migrates away from said signatures.

Signed-off-by: Abrar Rahman Protyasha <abrar@openrobotics.org>