### PR TITLE
Remove all uses of ament_target_dependencies.

### DIFF
--- a/turtlesim/CMakeLists.txt
+++ b/turtlesim/CMakeLists.txt
@@ -14,6 +14,7 @@ find_package(ament_cmake REQUIRED)
 find_package(ament_index_cpp REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(Qt5 REQUIRED COMPONENTS Widgets)
+find_package(rcl_interfaces REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_action REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
@@ -32,35 +33,49 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "srv/TeleportAbsolute.srv"
   "srv/TeleportRelative.srv")
 
-set(dependencies "ament_index_cpp" "geometry_msgs" "rclcpp" "rclcpp_action" "std_msgs" "std_srvs")
-
-set(turtlesim_node_SRCS
-  src/turtlesim.cpp
-  src/turtle.cpp
-  src/turtle_frame.cpp
-)
-set(turtlesim_node_HDRS
-  include/turtlesim/turtle_frame.hpp
-)
-
-qt5_wrap_cpp(turtlesim_node_MOCS ${turtlesim_node_HDRS})
+qt5_wrap_cpp(turtlesim_node_MOCS include/turtlesim/turtle_frame.hpp)
 
 rosidl_get_typesupport_target(cpp_typesupport_target "${PROJECT_NAME}" "rosidl_typesupport_cpp")
 
-add_executable(turtlesim_node ${turtlesim_node_SRCS} ${turtlesim_node_MOCS})
-target_link_libraries(turtlesim_node Qt5::Widgets)
-ament_target_dependencies(turtlesim_node ${dependencies})
-target_link_libraries(turtlesim_node "${cpp_typesupport_target}")
+add_executable(turtlesim_node
+  src/turtlesim.cpp
+  src/turtle.cpp
+  src/turtle_frame.cpp
+  ${turtlesim_node_MOCS}
+)
+target_link_libraries(turtlesim_node PRIVATE
+  ament_index_cpp::ament_index_cpp
+  ${cpp_typesupport_target}
+  ${geometry_msgs_TARGETS}
+  Qt5::Widgets
+  ${rcl_interfaces_TARGETS}
+  rclcpp::rclcpp
+  rclcpp_action::rclcpp_action
+  ${std_srvs_TARGETS}
+)
 
 add_executable(turtle_teleop_key tutorials/teleop_turtle_key.cpp)
-ament_target_dependencies(turtle_teleop_key ${dependencies})
-target_link_libraries(turtle_teleop_key "${cpp_typesupport_target}")
+target_link_libraries(turtle_teleop_key PRIVATE
+  "${cpp_typesupport_target}"
+  ${geometry_msgs_TARGETS}
+  rclcpp::rclcpp
+  rclcpp_action::rclcpp_action
+)
+
 add_executable(draw_square tutorials/draw_square.cpp)
-ament_target_dependencies(draw_square ${dependencies})
-target_link_libraries(draw_square "${cpp_typesupport_target}")
+target_link_libraries(draw_square PRIVATE
+  "${cpp_typesupport_target}"
+  ${geometry_msgs_TARGETS}
+  rclcpp::rclcpp
+  ${std_srvs_TARGETS}
+)
+
 add_executable(mimic tutorials/mimic.cpp)
-ament_target_dependencies(mimic ${dependencies})
-target_link_libraries(mimic "${cpp_typesupport_target}")
+target_link_libraries(mimic PRIVATE
+  "${cpp_typesupport_target}"
+  ${geometry_msgs_TARGETS}
+  rclcpp::rclcpp
+)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/turtlesim/package.xml
+++ b/turtlesim/package.xml
@@ -34,6 +34,7 @@
 
   <depend>ament_index_cpp</depend>
   <depend>geometry_msgs</depend>
+  <depend>rcl_interfaces</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_action</depend>
   <depend>std_msgs</depend>

--- a/turtlesim/src/turtle.cpp
+++ b/turtlesim/src/turtle.cpp
@@ -28,10 +28,22 @@
 
 #include "turtlesim/turtle.hpp"
 
-#include <math.h>
-
 #include <QColor>
 #include <QRgb>
+
+#include <cmath>
+#include <functional>
+#include <string>
+
+#include "geometry_msgs/msg/twist.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+#include "turtlesim/action/rotate_absolute.hpp"
+#include "turtlesim/msg/pose.hpp"
+#include "turtlesim/msg/color.hpp"
+#include "turtlesim/srv/set_pen.hpp"
+#include "turtlesim/srv/teleport_absolute.hpp"
+#include "turtlesim/srv/teleport_relative.hpp"
 
 #define DEFAULT_PEN_R 0xb3
 #define DEFAULT_PEN_G 0xb8

--- a/turtlesim/src/turtle_frame.cpp
+++ b/turtlesim/src/turtle_frame.cpp
@@ -32,6 +32,17 @@
 
 #include <cstdlib>
 #include <ctime>
+#include <functional>
+#include <string>
+
+#include "rcl_interfaces/msg/integer_range.hpp"
+#include "rcl_interfaces/msg/parameter_descriptor.hpp"
+#include "rcl_interfaces/msg/parameter_event.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "std_srvs/srv/empty.hpp"
+
+#include "turtlesim/srv/kill.hpp"
+#include "turtlesim/srv/spawn.hpp"
 
 #define DEFAULT_BG_R 0x45
 #define DEFAULT_BG_G 0x56


### PR DESCRIPTION
Instead we can just rely on target_link_libraries.