### PR TITLE
Use same QoS for all topic pub/subs

### DIFF
--- a/turtlesim/include/turtlesim/qos.hpp
+++ b/turtlesim/include/turtlesim/qos.hpp
@@ -38,7 +38,6 @@ inline rclcpp::QoS topic_qos()
 {
   return rclcpp::QoS(rclcpp::KeepLast(1)).reliable();
 }
-
 }  // namespace turtlesim
 
 #endif  // TURTLESIM__QOS_HPP_

--- a/turtlesim/include/turtlesim/qos.hpp
+++ b/turtlesim/include/turtlesim/qos.hpp
@@ -29,7 +29,7 @@
 #ifndef TURTLESIM__QOS_HPP_
 #define TURTLESIM__QOS_HPP_
 
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 
 namespace turtlesim
 {

--- a/turtlesim/include/turtlesim/qos.hpp
+++ b/turtlesim/include/turtlesim/qos.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2009, Willow Garage, Inc.
+// Copyright (c) 2024, Open Source Robotics Foundation, Inc.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:

--- a/turtlesim/include/turtlesim/qos.hpp
+++ b/turtlesim/include/turtlesim/qos.hpp
@@ -29,6 +29,8 @@
 #ifndef TURTLESIM__QOS_HPP_
 #define TURTLESIM__QOS_HPP_
 
+#include "rclcpp/rclcpp.hpp"
+
 namespace turtlesim
 {
 // Return the QoS used for all publishers/subscriptions.

--- a/turtlesim/include/turtlesim/qos.hpp
+++ b/turtlesim/include/turtlesim/qos.hpp
@@ -26,39 +26,17 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-#include <rclcpp/rclcpp.hpp>
-#include <turtlesim/msg/pose.hpp>
-#include <geometry_msgs/msg/twist.hpp>
+#ifndef TURTLESIM__QOS_HPP_
+#define TURTLESIM__QOS_HPP_
 
-#include "turtlesim/qos.hpp"
-
-class MimicNode : public rclcpp::Node
+namespace turtlesim
 {
-public:
-  MimicNode()
-  : rclcpp::Node("turtle_mimic")
-  {
-    const rclcpp::QoS qos = turtlesim::topic_qos();
-    twist_pub_ = this->create_publisher<geometry_msgs::msg::Twist>("output/cmd_vel", qos);
-    pose_sub_ = this->create_subscription<turtlesim::msg::Pose>(
-      "input/pose", qos, std::bind(&MimicNode::poseCallback, this, std::placeholders::_1));
-  }
-
-private:
-  void poseCallback(const turtlesim::msg::Pose::ConstSharedPtr pose)
-  {
-    geometry_msgs::msg::Twist twist;
-    twist.angular.z = pose->angular_velocity;
-    twist.linear.x = pose->linear_velocity;
-    twist_pub_->publish(twist);
-  }
-
-  rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr twist_pub_;
-  rclcpp::Subscription<turtlesim::msg::Pose>::SharedPtr pose_sub_;
-};
-
-int main(int argc, char ** argv)
+// Return the QoS used for all publishers/subscriptions.
+inline rclcpp::QoS topic_qos()
 {
-  rclcpp::init(argc, argv);
-  rclcpp::spin(std::make_shared<MimicNode>());
+  return rclcpp::QoS(rclcpp::KeepLast(1)).reliable();
 }
+
+}  // namespace turtlesim
+
+#endif  // TURTLESIM__QOS_HPP_

--- a/turtlesim/include/turtlesim/qos.hpp
+++ b/turtlesim/include/turtlesim/qos.hpp
@@ -36,7 +36,7 @@ namespace turtlesim
 // Return the QoS used for all publishers/subscriptions.
 inline rclcpp::QoS topic_qos()
 {
-  return rclcpp::QoS(rclcpp::KeepLast(1)).reliable();
+  return rclcpp::QoS(rclcpp::KeepLast(7)).reliable();
 }
 }  // namespace turtlesim
 

--- a/turtlesim/src/turtle.cpp
+++ b/turtlesim/src/turtle.cpp
@@ -46,7 +46,6 @@
 #include "turtlesim/srv/teleport_relative.hpp"
 #include "turtlesim/qos.hpp"
 
-
 #define DEFAULT_PEN_R 0xb3
 #define DEFAULT_PEN_G 0xb8
 #define DEFAULT_PEN_B 0xff

--- a/turtlesim/src/turtle.cpp
+++ b/turtlesim/src/turtle.cpp
@@ -27,6 +27,7 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 #include "turtlesim/turtle.hpp"
+#include "turtlesim/qos.hpp"
 
 #include <QColor>
 #include <QRgb>
@@ -72,7 +73,7 @@ Turtle::Turtle(
 {
   pen_.setWidth(3);
 
-  rclcpp::QoS qos(rclcpp::KeepLast(7));
+  const rclcpp::QoS qos = topic_qos();
   velocity_sub_ = nh_->create_subscription<geometry_msgs::msg::Twist>(
     real_name + "/cmd_vel", qos, std::bind(
       &Turtle::velocityCallback, this,

--- a/turtlesim/src/turtle.cpp
+++ b/turtlesim/src/turtle.cpp
@@ -27,7 +27,6 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 #include "turtlesim/turtle.hpp"
-#include "turtlesim/qos.hpp"
 
 #include <QColor>
 #include <QRgb>
@@ -45,6 +44,8 @@
 #include "turtlesim/srv/set_pen.hpp"
 #include "turtlesim/srv/teleport_absolute.hpp"
 #include "turtlesim/srv/teleport_relative.hpp"
+#include "turtlesim/qos.hpp"
+
 
 #define DEFAULT_PEN_R 0xb3
 #define DEFAULT_PEN_G 0xb8

--- a/turtlesim/tutorials/draw_square.cpp
+++ b/turtlesim/tutorials/draw_square.cpp
@@ -36,6 +36,8 @@
 #include <std_srvs/srv/empty.hpp>
 #include <turtlesim/msg/pose.hpp>
 
+#include "turtlesim/qos.hpp"
+
 #define PI 3.141592f
 
 class DrawSquare final : public rclcpp::Node
@@ -44,11 +46,12 @@ public:
   explicit DrawSquare(const rclcpp::NodeOptions & options = rclcpp::NodeOptions())
   : rclcpp::Node("draw_square", options)
   {
-    twist_pub_ = this->create_publisher<geometry_msgs::msg::Twist>("turtle1/cmd_vel", 1);
+    const rclcpp::QoS qos = turtlesim::topic_qos();
+    twist_pub_ = this->create_publisher<geometry_msgs::msg::Twist>("turtle1/cmd_vel", qos);
 
     pose_sub_ =
       this->create_subscription<turtlesim::msg::Pose>(
-      "turtle1/pose", 1, std::bind(&DrawSquare::poseCallback, this, std::placeholders::_1));
+      "turtle1/pose", qos, std::bind(&DrawSquare::poseCallback, this, std::placeholders::_1));
 
     reset_client_ = this->create_client<std_srvs::srv::Empty>("reset");
 

--- a/turtlesim/tutorials/teleop_turtle_key.cpp
+++ b/turtlesim/tutorials/teleop_turtle_key.cpp
@@ -44,6 +44,8 @@
 # include <unistd.h>  // NO LINT
 #endif
 
+#include "turtlesim/qos.hpp"
+
 static constexpr char KEYCODE_RIGHT = 0x43;
 static constexpr char KEYCODE_LEFT = 0x44;
 static constexpr char KEYCODE_UP = 0x41;
@@ -186,7 +188,9 @@ public:
     nh_->declare_parameter("scale_angular", 2.0);
     nh_->declare_parameter("scale_linear", 2.0);
 
-    twist_pub_ = nh_->create_publisher<geometry_msgs::msg::Twist>("turtle1/cmd_vel", 1);
+    twist_pub_ = nh_->create_publisher<geometry_msgs::msg::Twist>(
+      "turtle1/cmd_vel",
+      turtlesim::topic_qos());
     rotate_absolute_client_ = rclcpp_action::create_client<turtlesim::action::RotateAbsolute>(
       nh_,
       "turtle1/rotate_absolute");


### PR DESCRIPTION
This PR ensures that all topic publishers and subscriptions are configured with the same QoS settings. Given that the history depth for the `turtle1/pose` subscription was previously 1, I would observe the `draw_square` executable would sometimes wait indefinitely if the message was dropped. This could happen if the Default reliability is BEST_EFFORT instead of RELIABLE. With the changes, the reliability is RELIABLE and all pub/subs have compatible settings.