### PR TITLE
[teleop_turtle_key] update usage string to match keys captured by key…

### DIFF
--- a/turtlesim/tutorials/teleop_turtle_key.cpp
+++ b/turtlesim/tutorials/teleop_turtle_key.cpp
@@ -205,8 +205,8 @@ public:
     puts("Reading from keyboard");
     puts("---------------------------");
     puts("Use arrow keys to move the turtle.");
-    puts("Use G|B|V|C|D|E|R|T keys to rotate to absolute orientations. 'F' to cancel a rotation.");
-    puts("'Q' to quit.");
+    puts("Use g|b|v|c|d|e|r|t keys to rotate to absolute orientations. 'f' to cancel a rotation.");
+    puts("'q' to quit.");
 
     while (running) {
       // get the next event from the keyboard


### PR DESCRIPTION
…board

The keys actually captured in the code are the lowercase versions:
https://github.com/ros/ros_tutorials/blob/fa2868639263a188e97e1b8a1e895d0cb10f7a58/turtlesim/tutorials/teleop_turtle_key.cpp#L53-L62


On Windows it will still be the uppercase version but I suppose it is the case for case insensitive shells so this change in help string shouldn't impact the users