### PR TITLE
get rid of deprecated rclcpp::spin_some()

### DIFF
--- a/turtlesim/include/turtlesim/turtle_frame.hpp
+++ b/turtlesim/include/turtlesim/turtle_frame.hpp
@@ -110,6 +110,8 @@ private:
   rclcpp::Service<turtlesim_msgs::srv::Kill>::SharedPtr kill_srv_;
   rclcpp::Subscription<rcl_interfaces::msg::ParameterEvent>::SharedPtr parameter_event_sub_;
 
+  rclcpp::executors::SingleThreadedExecutor executor_;
+
   typedef std::map<std::string, TurtlePtr> M_Turtle;
   M_Turtle turtles_;
   uint32_t id_counter_;

--- a/turtlesim/src/turtle_frame.cpp
+++ b/turtlesim/src/turtle_frame.cpp
@@ -70,6 +70,8 @@ TurtleFrame::TurtleFrame(rclcpp::Node::SharedPtr & node_handle, QWidget * parent
   connect(update_timer_, SIGNAL(timeout()), this, SLOT(onUpdate()));
 
   nh_ = node_handle;
+  executor_.add_node(nh_);
+
   rcl_interfaces::msg::IntegerRange range;
   range.from_value = 0;
   range.step = 1;
@@ -267,7 +269,7 @@ void TurtleFrame::onUpdate()
     return;
   }
 
-  rclcpp::spin_some(nh_);
+  executor_.spin_some();
 
   updateTurtles();
 }


### PR DESCRIPTION
Related with https://github.com/ros2/rclcpp/pull/2848