### PR TITLE
bump cpp20, contains and std::numbers

### DIFF
--- a/turtlesim/CMakeLists.txt
+++ b/turtlesim/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.20)
 project(turtlesim)
 
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD 20)
   set(CMAKE_CXX_STANDARD_REQUIRED ON)
 endif()
 

--- a/turtlesim/include/turtlesim/turtle.hpp
+++ b/turtlesim/include/turtlesim/turtle.hpp
@@ -49,7 +49,7 @@
 #include <QPointF>
 
 #include <memory>
-#include <numbers>
+#include <numbers>  // NOLINT(build/include_order)
 #include <string>
 #include <vector>
 

--- a/turtlesim/include/turtlesim/turtle.hpp
+++ b/turtlesim/include/turtlesim/turtle.hpp
@@ -49,14 +49,15 @@
 #include <QPointF>
 
 #include <memory>
+#include <numbers>
 #include <string>
 #include <vector>
 
-#define PI 3.14159265
-#define TWO_PI 2.0 * PI
-
 namespace turtlesim
 {
+inline constexpr double PI = std::numbers::pi;
+inline constexpr double TWO_PI = 2.0 * std::numbers::pi;
+
 class Turtle
 {
 public:

--- a/turtlesim/src/turtle.cpp
+++ b/turtlesim/src/turtle.cpp
@@ -182,8 +182,10 @@ void Turtle::rotateAbsoluteAcceptCallback(
     rotate_absolute_goal_handle_->abort(rotate_absolute_result_);
   }
   rotate_absolute_goal_handle_ = goal_handle;
-  rotate_absolute_feedback_.reset(new turtlesim_msgs::action::RotateAbsolute::Feedback);
-  rotate_absolute_result_.reset(new turtlesim_msgs::action::RotateAbsolute::Result);
+  rotate_absolute_feedback_ =
+    std::make_shared<turtlesim_msgs::action::RotateAbsolute::Feedback>();
+  rotate_absolute_result_ =
+    std::make_shared<turtlesim_msgs::action::RotateAbsolute::Result>();
   rotate_absolute_start_orient_ = orient_;
 }
 
@@ -202,11 +204,7 @@ bool Turtle::update(
   qreal old_orient = orient_;
 
   // first process any teleportation requests, in order
-  V_TeleportRequest::iterator it = teleport_requests_.begin();
-  V_TeleportRequest::iterator end = teleport_requests_.end();
-  for (; it != end; ++it) {
-    const TeleportRequest & req = *it;
-
+  for (const TeleportRequest & req : teleport_requests_) {
     QPointF old_pos = pos_;
     if (req.relative) {
       orient_ += req.theta;

--- a/turtlesim/src/turtle_frame.cpp
+++ b/turtlesim/src/turtle_frame.cpp
@@ -32,7 +32,7 @@
 
 #include <cstdlib>
 #include <ctime>
-#include <format>
+#include <format>  // NOLINT(build/include_order)
 #include <functional>
 #include <string>
 

--- a/turtlesim/src/turtle_frame.cpp
+++ b/turtlesim/src/turtle_frame.cpp
@@ -296,10 +296,8 @@ void TurtleFrame::paintEvent(QPaintEvent * event)
 
   painter.drawImage(QPoint(0, 0), path_image_);
 
-  M_Turtle::iterator it = turtles_.begin();
-  M_Turtle::iterator end = turtles_.end();
-  for (; it != end; ++it) {
-    it->second->paint(painter);
+  for (auto & [name, turtle] : turtles_) {
+    turtle->paint(painter);
   }
 }
 
@@ -311,10 +309,8 @@ void TurtleFrame::updateTurtles()
   }
 
   bool modified = false;
-  M_Turtle::iterator it = turtles_.begin();
-  M_Turtle::iterator end = turtles_.end();
-  for (; it != end; ++it) {
-    modified |= it->second->update(
+  for (auto & [name, turtle] : turtles_) {
+    modified |= turtle->update(
       0.001 * update_timer_->interval(), path_painter_, path_image_, width_in_meters_,
       height_in_meters_);
   }

--- a/turtlesim/src/turtle_frame.cpp
+++ b/turtlesim/src/turtle_frame.cpp
@@ -32,6 +32,7 @@
 
 #include <cstdlib>
 #include <ctime>
+#include <format>
 #include <functional>
 #include <string>
 
@@ -222,7 +223,7 @@ void TurtleFrame::parameterEventCallback(
 
 bool TurtleFrame::hasTurtle(const std::string & name)
 {
-  return turtles_.find(name) != turtles_.end();
+  return turtles_.contains(name);
 }
 
 std::string TurtleFrame::spawnTurtle(const std::string & name, float x, float y, float angle)
@@ -236,10 +237,8 @@ std::string TurtleFrame::spawnTurtle(
 {
   std::string real_name = name;
   if (real_name.empty()) {
-    do{
-      std::stringstream ss;
-      ss << "turtle" << ++id_counter_;
-      real_name = ss.str();
+    do {
+      real_name = std::format("turtle{}", ++id_counter_);
     } while (hasTurtle(real_name));
   } else {
     if (hasTurtle(real_name)) {

--- a/turtlesim/tutorials/draw_square.cpp
+++ b/turtlesim/tutorials/draw_square.cpp
@@ -30,7 +30,7 @@
 #include <cmath>
 #include <functional>
 #include <memory>
-#include <numbers>
+#include <numbers>  // NOLINT(build/include_order)
 
 #include <geometry_msgs/msg/twist.hpp>
 #include <rclcpp/rclcpp.hpp>

--- a/turtlesim/tutorials/draw_square.cpp
+++ b/turtlesim/tutorials/draw_square.cpp
@@ -30,6 +30,7 @@
 #include <cmath>
 #include <functional>
 #include <memory>
+#include <numbers>
 
 #include <geometry_msgs/msg/twist.hpp>
 #include <rclcpp/rclcpp.hpp>
@@ -38,7 +39,7 @@
 
 #include "turtlesim/qos.hpp"
 
-#define PI 3.141592f
+inline constexpr float PI = std::numbers::pi_v<float>;
 
 class DrawSquare final : public rclcpp::Node
 {
@@ -62,7 +63,7 @@ public:
   }
 
 private:
-  enum State
+  enum class State
   {
     FORWARD,
     STOP_FORWARD,
@@ -106,7 +107,7 @@ private:
   {
     if (hasStopped()) {
       RCLCPP_INFO(this->get_logger(), "Reached goal");
-      state_ = TURN;
+      state_ = State::TURN;
       goal_pose_.x = current_pose_.x;
       goal_pose_.y = current_pose_.y;
       goal_pose_.theta = fmod(current_pose_.theta + PI / 2.0f, 2.0f * PI);
@@ -124,7 +125,7 @@ private:
   {
     if (hasStopped()) {
       RCLCPP_INFO(this->get_logger(), "Reached goal");
-      state_ = FORWARD;
+      state_ = State::FORWARD;
       goal_pose_.x = cos(current_pose_.theta) * 2 + current_pose_.x;
       goal_pose_.y = sin(current_pose_.theta) * 2 + current_pose_.y;
       goal_pose_.theta = current_pose_.theta;
@@ -137,7 +138,7 @@ private:
   void forward()
   {
     if (hasReachedGoal()) {
-      state_ = STOP_FORWARD;
+      state_ = State::STOP_FORWARD;
       commandTurtle(0, 0);
     } else {
       commandTurtle(1.0f, 0);
@@ -147,7 +148,7 @@ private:
   void turn()
   {
     if (hasReachedGoal()) {
-      state_ = STOP_TURN;
+      state_ = State::STOP_TURN;
       commandTurtle(0, 0);
     } else {
       commandTurtle(0, 0.4f);
@@ -166,21 +167,27 @@ private:
 
     if (!first_goal_set_) {
       first_goal_set_ = true;
-      state_ = FORWARD;
+      state_ = State::FORWARD;
       goal_pose_.x = cos(current_pose_.theta) * 2 + current_pose_.x;
       goal_pose_.y = sin(current_pose_.theta) * 2 + current_pose_.y;
       goal_pose_.theta = current_pose_.theta;
       printGoal();
     }
 
-    if (state_ == FORWARD) {
-      forward();
-    } else if (state_ == STOP_FORWARD) {
-      stopForward();
-    } else if (state_ == TURN) {
-      turn();
-    } else if (state_ == STOP_TURN) {
-      stopTurn();
+    using enum State;
+    switch (state_) {
+      case FORWARD:
+        forward();
+        break;
+      case STOP_FORWARD:
+        stopForward();
+        break;
+      case TURN:
+        turn();
+        break;
+      case STOP_TURN:
+        stopTurn();
+        break;
     }
   }
 
@@ -188,7 +195,7 @@ private:
   turtlesim_msgs::msg::Pose goal_pose_;
   bool first_goal_set_ = false;
   bool first_pose_set_ = false;
-  State state_ = FORWARD;
+  State state_ = State::FORWARD;
 
   rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr twist_pub_;
   rclcpp::Subscription<turtlesim_msgs::msg::Pose>::SharedPtr pose_sub_;


### PR DESCRIPTION
  - Bump CMAKE_CXX_STANDARD 17 -> 20.
  - Replace PI/TWO_PI macros with namespace-scoped std::numbers constexpr constants
  - std::map::contains()
  - std::format() 
  - Scoped enum class State

@asymingt FYI

Claude Opus 4.7